### PR TITLE
fix(loader): using new RWXMaterialManager to avoid race conditions, better handling of sign material ratio

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "rxjs": "^7.5.5",
     "three": "^0.143.0",
     "three-mesh-bvh": "^0.5.10",
-    "three-rwx-loader": "^0.6.5",
+    "three-rwx-loader": "^0.7.0",
     "tslib": "^2.4.0",
     "zone.js": "^0.11.5"
   },

--- a/src/app/world/object.service.ts
+++ b/src/app/world/object.service.ts
@@ -304,8 +304,9 @@ export class ObjectService {
             if (color != null) {
               newRWXMat.color = [color.r / 255.0, color.g / 255.0, color.b / 255.0]
             }
-            this.rwxMaterialManager.currentRWXMaterial = newRWXMat
-            const curMat = this.rwxMaterialManager.getCurrentMaterial()
+            const signature = newRWXMat.getMatSignature()
+            this.rwxMaterialManager.addRWXMaterial(newRWXMat, signature)
+            const curMat = this.rwxMaterialManager.getThreeMaterialPack(signature)
             newMaterials.push(curMat.threeMat)
             promises.push(forkJoin(curMat.loadingPromises))
           }
@@ -321,7 +322,6 @@ export class ObjectService {
         child.material.needsUpdate = true
       }
     })
-    this.rwxMaterialManager.resetCurrentMaterialList()
     return forkJoin(promises)
   }
 


### PR DESCRIPTION
Can be tested here: https://lemuria.waxtopia.nl/

Nothing too visible, but it fixes material handling for signs in a few annoying cases and overall material management across objects has been made safer.